### PR TITLE
fix(menu): correct switch case mapping in main menu

### DIFF
--- a/Valkan/Internal/ui/terminal.go
+++ b/Valkan/Internal/ui/terminal.go
@@ -253,13 +253,6 @@ func ShowMenu() {
 			}
 
 		case "3":
-			showHelp()
-
-		case "4":
-			fmt.Println("Saindo...")
-			return
-
-		case "5":
 			fmt.Println(Yellow + "Iniciando Recon (Busca de Subdomínios)..." + Reset)
 
 			fmt.Print("Digite o domínio (ex: exemplo.com): ")
@@ -303,6 +296,13 @@ func ShowMenu() {
 		default:
 			fmt.Println(Red + "Opção inválida, tente novamente." + Reset)
 		}
+
+		case "4":
+			showHelp()
+
+		case "5":
+			fmt.Println("Saindo...")
+			return
 	}
 }
 


### PR DESCRIPTION
## The original switch case mapping was incorrect:

- **Option 3** was wrongly triggering the functionality of option 5.
- **Option 4** was also executing the method for option 5.
- **Option 5** was pointing to the method for option 3.

## This fix realigns each case to correspond properly with the displayed menu items:

- [ ] 1) Scanner
- [ ] 2) Discovery
- [X] 3) Recon (Subdomain Finder)
- [X] 4) Help
- [X] 5) Exit