### PR TITLE
fix(menu): correct misplaced closing brace in switch case menu

### DIFF
--- a/Valkan/Internal/ui/terminal.go
+++ b/Valkan/Internal/ui/terminal.go
@@ -293,16 +293,16 @@ func ShowMenu() {
 				}
 			}
 
-		default:
-			fmt.Println(Red + "Opção inválida, tente novamente." + Reset)
-		}
-
 		case "4":
 			showHelp()
 
 		case "5":
 			fmt.Println("Saindo...")
 			return
+
+		default:
+			fmt.Println(Red + "Opção inválida, tente novamente." + Reset)
+		}
 	}
 }
 


### PR DESCRIPTION
- Fixed syntax errors caused by premature closing brace in the switch statement handling menu options.
- Ensured all case blocks (**3, 4, 5**) are properly grouped inside a single switch without extra braces.